### PR TITLE
Fix typo in the configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,7 @@ issuance:
    tanExpirationHours: 2
    expiration:
       vaccination: 365
-      recoverty: 365
+      recovery: 365
       test: 60
 ```
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,7 +50,7 @@ issuance:
   contextFile: context/context.json
   expiration:
     vaccination: 365
-    recoverty: 365
+    recovery: 365
     test: 3
   endpoints:
     frontendIssuing: true


### PR DESCRIPTION
The default key `recovery` contained a typo. I have not checked further, where this configuration is loaded and how it is used, but I suppose it could lead to possible miss-configuration of the system.

I've grepped for the misspelled word `recoverty` and could not find it anywhere else (in this repo).